### PR TITLE
[#69] 로그인, 회원가입 실패시 오류 메시지를 토스트로 보여줌

### DIFF
--- a/snowe/Snowman/Source/Feature/Login/SignInViewController.swift
+++ b/snowe/Snowman/Source/Feature/Login/SignInViewController.swift
@@ -118,9 +118,23 @@ class SignInViewController: BaseViewController {
                 completion(data)
             case .requestErr(let errorResponse):
                 dump(errorResponse)
+                guard let data = errorResponse as? ErrorResponse else { return }
+                self.showToastMessageAlert(message: data.message)
             default:
                 print("sign in error")
             }
+        }
+    }
+
+    func showToastMessageAlert(message: String) {
+        let alert = UIAlertController(title: message,
+                                      message: "",
+                                      preferredStyle: .alert)
+
+        present(alert, animated: true, completion: nil)
+
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0) {
+            alert.dismiss(animated: true)
         }
     }
 

--- a/snowe/Snowman/Source/Feature/SignUp/SignUpPasswordViewController.swift
+++ b/snowe/Snowman/Source/Feature/SignUp/SignUpPasswordViewController.swift
@@ -106,7 +106,7 @@ class SignUpPasswordViewController: BaseViewController {
         guard let password = self.passwordTextField.text else { return }
         guard let passwordCheck = self.passwordCheckTextField.text else { return }
 
-        if userName == password || userName == passwordCheck {
+        if userName == password {
             showToastMessageAlert(message: "아이디, 비밀번호가 일치합니다. 다르게 입력해주세요.")
         } else if password != passwordCheck {
             showToastMessageAlert(message: "비밀번호가 일치하지 않습니다.")
@@ -137,6 +137,8 @@ class SignUpPasswordViewController: BaseViewController {
                 completion(data)
             case .requestErr(let errorResponse):
                 dump(errorResponse)
+                guard let data = errorResponse as? ErrorResponse else { return }
+                self.showToastMessageAlert(message: data.message)
             default:
                 print("sign up error")
             }

--- a/snowe/Snowman/Source/Model/APIModel/ErrorResponse.swift
+++ b/snowe/Snowman/Source/Model/APIModel/ErrorResponse.swift
@@ -6,7 +6,7 @@
 //
 
 struct ErrorResponse: Codable {
-    let timestamp: String
+    let timeStamp: String
     let status: Int
     let message: String
     let path, code, error: String?


### PR DESCRIPTION
- 로그인 화면에서 로그인 실패하면 오류 메시지를 토스트로 보여줌
- 회원가입 화면에서 회원가입 실패하면 오류 메시지를 토스트로 보여줌

|로그인 화면|회원가입 화면|
|---|---|
|![스크린샷 2022-01-16 오전 1 22 27](https://user-images.githubusercontent.com/39911797/149629447-e77dba4d-22b0-44a7-9a7f-81a62389b1c2.png)|![스크린샷 2022-01-16 오전 1 22 54](https://user-images.githubusercontent.com/39911797/149629448-c3c6854b-8a68-44f4-81e2-84a2d9452042.png)|