### PR TITLE
[#70] 투두 선택하면 액션 시트 띄우기

### DIFF
--- a/snowe/Snowman/Source/Model/APIModel/ErrorResponse.swift
+++ b/snowe/Snowman/Source/Model/APIModel/ErrorResponse.swift
@@ -6,7 +6,7 @@
 //
 
 struct ErrorResponse: Codable {
-    let timestamp: String
+    let timeStamp: String
     let status: Int
     let message: String
     let path, code, error: String?

--- a/snowe/Snowman/Source/Network/Service/TodoService.swift
+++ b/snowe/Snowman/Source/Network/Service/TodoService.swift
@@ -52,7 +52,6 @@ final class TodoService {
             case .failure(let err):
                 print(err)
             }
-
         }
     }
 
@@ -93,7 +92,6 @@ final class TodoService {
             }
             return .success(decodedData)
         case 204:
-            // delete response 확인하기
             return .success(data)
         case 400..<500:
             guard let decodedData = try? decoder.decode(ErrorResponse.self, from: data) else {


### PR DESCRIPTION
- 홈, 캘린더 화면에서 입력이 안 된 투두 셀 선택하면 바로 키보드가 올라옴
- 홈, 캘린더 화면에서 입력이 된 투두 셀 선택하면 투두 설정 액션시트가 올라옴

|홈|홈|캘린더|캘린더|
|---|---|---|---|
|![스크린샷 2022-01-16 오전 1 30 30](https://user-images.githubusercontent.com/39911797/149629660-06e61cfb-b3d8-4fce-a82e-0708db59ae4e.png)|![스크린샷 2022-01-16 오전 1 30 32](https://user-images.githubusercontent.com/39911797/149629663-d63e6da7-2505-429c-acd5-99f5240a7ce6.png)|![스크린샷 2022-01-16 오전 1 30 57](https://user-images.githubusercontent.com/39911797/149629673-62904b5e-9059-4775-aa9f-5b9524d74e05.png)|![스크린샷 2022-01-16 오전 1 30 36](https://user-images.githubusercontent.com/39911797/149629690-c551a799-9e0e-495d-b910-883a3ca3f163.png)|

